### PR TITLE
Replace content with slot

### DIFF
--- a/twitter-widgets.html
+++ b/twitter-widgets.html
@@ -44,7 +44,7 @@ For more information, see https://dev.twitter.com/web/javascript.
       }
     </style>
 
-    <content></content>
+    <slot></slot>
 
   </template>
 


### PR DESCRIPTION
Polymer 2.x or above strictly uses slot tag so, content tag will
no longer work.